### PR TITLE
施設詳細ページ用のデータを作成

### DIFF
--- a/app/contents/park-item/data.ts
+++ b/app/contents/park-item/data.ts
@@ -1,1 +1,101 @@
 // 実データ本体
+import { Category } from "./type";
+
+export const facilitiesData: Category[] = [
+  {
+    category: "駐車場",
+    items: [
+      {
+        id: 1,
+        name: "区営地下駐車場出入口",
+        description: "区営地下駐車場の出入口です。",
+        image: "/images/underground-parking.jpg",
+      },
+      {
+        id: 12,
+        name: "スポーツセンター地下駐車場出入口",
+        description: "スポーツセンター地下駐車場の出入口です。",
+        image: "/images/sports-center-parking.jpg",
+      },
+    ],
+  },
+  {
+    category: "スポーツ施設",
+    items: [
+      {
+        id: 2,
+        name: "区営浜町運動場",
+        description: "区営の運動場です。",
+        image: "/images/sports-ground.jpg",
+      },
+      {
+        id: 3,
+        name: "野球スタンド",
+        description: "野球観戦用のスタンドです。",
+        image: "/images/baseball-stand.jpg",
+      },
+      {
+        id: 7,
+        name: "区営総合スポーツセンター",
+        description: "総合的なスポーツ施設です。",
+        image: "/images/sports-center.jpg",
+      },
+    ],
+  },
+  {
+    category: "公園・広場",
+    items: [
+      {
+        id: 4,
+        name: "芝生広場",
+        description: "広々とした芝生広場です。",
+        image: "/images/lawn-area.jpg",
+      },
+      {
+        id: 11,
+        name: "遊具広場",
+        description: "子供向けの遊具が設置された広場です。",
+        image: "/images/playground.jpg",
+      },
+    ],
+  },
+  {
+    category: "自然・景観",
+    items: [
+      {
+        id: 5,
+        name: "もや立ちの池",
+        description: "自然豊かな池です。",
+        image: "/images/pond.jpg",
+      },
+      {
+        id: 6,
+        name: "桜の樹林",
+        description: "桜が美しい樹林エリアです。",
+        image: "/images/cherry-trees.jpg",
+      },
+    ],
+  },
+  {
+    category: "レクリエーション",
+    items: [
+      {
+        id: 8,
+        name: "デイキャンプ場",
+        description: "日帰りキャンプが楽しめる場所です。",
+        image: "/images/day-camp.jpg",
+      },
+    ],
+  },
+  {
+    category: "水辺・遊歩道",
+    items: [
+      {
+        id: 13,
+        name: "隅田川テラス",
+        description: "隅田川沿いのテラスです。",
+        image: "/images/sumida-terrace.jpg",
+      },
+    ],
+  },
+];

--- a/app/contents/park-item/index.ts
+++ b/app/contents/park-item/index.ts
@@ -1,1 +1,4 @@
 // 再エクスポート用
+
+export { type Facility, type Category } from "./type";
+export { facilitiesData } from "./data";

--- a/app/contents/park-item/type.ts
+++ b/app/contents/park-item/type.ts
@@ -1,1 +1,14 @@
 // 型定義（Facility, FacilityCategory）
+// 型定義（Facility, FacilityCategory）
+
+export type Facility = {
+  id: number;
+  name: string;
+  description: string;
+  image: string;
+};
+
+export type Category = {
+  category: string;
+  items: Facility[];
+};


### PR DESCRIPTION
## 概要

公園施設詳細ページに使用するデータを作成しました。

## 内容

- `app/contents/park-item/data.ts` にテンプレートデータを定義
  - カテゴリごとに施設名、説明、を格納
- 型定義（`type.ts`）とエントリポイント（`index.ts`）もあわせて作成

## 補足

- 今後 UI 実装時に参照される想定です
- データ構造の改善や追加要素（タグ・IDなど）は随時調整予定
- データは以下でインポート可能です。
- import { Facility, Category, facilitiesData } from                       │
│     "../contents/park-item";      